### PR TITLE
ARM/dt: hammerhead: Reduce minimum panel brightness

### DIFF
--- a/arch/arm/boot/dts/lge/msm8974-g2/msm8974-lge-common/msm8974-lge-panel.dtsi
+++ b/arch/arm/boot/dts/lge/msm8974-g2/msm8974-lge-common/msm8974-lge-panel.dtsi
@@ -2019,7 +2019,7 @@ mdss_dsi_lgd_960p_video: qcom,mdss_dsi_lgd_960p_video {
 			reg = <0x38>;
 			lm3630,lcd_bl_en = <&msmgpio 49 0x00>;
 			lm3630,max_current = <0x17>;
-			lm3630,min_brightness = <0x05>;
+			lm3630,min_brightness = <0x03>;
 			lm3630,default_brightness = <233>;
 			lm3630,max_brightness = <0xFF>;
 			lm3630,enable_pwm = <0>;
@@ -2050,7 +2050,7 @@ mdss_dsi_lgd_960p_video: qcom,mdss_dsi_lgd_960p_video {
 			reg = <0x38>;
 			lm3630,lcd_bl_en = <&msmgpio 91 0x00>;
 			lm3630,max_current = <0x17>;
-			lm3630,min_brightness = <0x05>;
+			lm3630,min_brightness = <0x03>;
 			lm3630,default_brightness = <233>;
 			lm3630,max_brightness = <0xFF>;
 			lm3630,enable_pwm = <0>;
@@ -2081,7 +2081,7 @@ mdss_dsi_lgd_960p_video: qcom,mdss_dsi_lgd_960p_video {
 			reg = <0x38>;
 			lm3630,lcd_bl_en = <&msmgpio 49 0x00>;
 			lm3630,max_current = <0x17>;
-			lm3630,min_brightness = <0x05>;
+			lm3630,min_brightness = <0x03>;
 			lm3630,default_brightness = <233>;
 			lm3630,max_brightness = <0xFF>;
 			lm3630,enable_pwm = <0>;


### PR DESCRIPTION
Default minimum brightness is a tad too high, this change makes reading
in a dark environment much more enjoyable. A value of 3 is still within
the valid range (see lm3630 blmap).
