### PR TITLE
bcmdhd: Reset the hang flag after the notifications are sent and put …

### DIFF
--- a/drivers/net/wireless/bcmdhd/src/dhd/sys/dhd_linux.c
+++ b/drivers/net/wireless/bcmdhd/src/dhd/sys/dhd_linux.c
@@ -8987,6 +8987,7 @@ static void dhd_hang_process(void *dhd_info, void *event_info, u8 event)
 		wl_cfg80211_hang(dev, WLAN_REASON_UNSPECIFIED);
 #endif
 	}
+	dhd->pub.hang_was_sent = 0;
 }
 
 #ifdef CUSTOMER_HW4


### PR DESCRIPTION
…back the pseudo-tuning code in mmc to avoid erroring out on reinit

Original commit: 30cf5909669d432e39bb72522bb527115eb9bd68
